### PR TITLE
.env.example添加ACCESS_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 SERVER_ADDR=dns:localhost:5230
 BOT_TOKEN=your_bot_token
+ACCESS_TOKEN=userId:access_token

--- a/config.go
+++ b/config.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Config struct {
-	ServerAddr string `env:"SERVER_ADDR,required"`
-	BotToken   string `env:"BOT_TOKEN,required"`
+	ServerAddr  string `env:"SERVER_ADDR,required"`
+	BotToken    string `env:"BOT_TOKEN,required"`
+	AccessToken string `env:"ACCESS_TOKEN"`
 }
 
 func getConfigFromEnv() (*Config, error) {

--- a/memogram.go
+++ b/memogram.go
@@ -59,6 +59,15 @@ func NewService() (*Service, error) {
 	}
 	s.bot = b
 
+	if config.AccessToken != "" {
+		parts := strings.Split(config.AccessToken, ":")
+		if len(parts) == 2 {
+			userID := parts[0]
+			accessToken := parts[1]
+			userAccessTokenCache.Store(userID, accessToken)
+		}
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION
Add ACCESS_TOKEN to .env.example and read it in NewService function.

* **config.go**
  - Add `AccessToken` field to `Config` struct.
  - Parse and load `ACCESS_TOKEN` from the environment in `getConfigFromEnv` function.

* **memogram.go**
  - Read `ACCESS_TOKEN` from the configuration in `NewService` function.
  - If `ACCESS_TOKEN` is not blank, split it with `:`, get `userId` and `access_token`, and store them in `userAccessTokenCache`.

* **.env.example**
  - Add `ACCESS_TOKEN` variable in the format `userId:access_token`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wolfsilver/telegram-integration?shareId=115c59c8-ef60-4040-8f4e-e2b420f4bca4).