### PR TITLE
Fix URL in bot message

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	ServerAddr  string `env:"SERVER_ADDR,required"`
 	BotToken    string `env:"BOT_TOKEN,required"`
+	MemosAddr		string `env:"MEMOS_ADDR"`
 	AccessToken string `env:"ACCESS_TOKEN"`
 }
 

--- a/memogram.go
+++ b/memogram.go
@@ -194,7 +194,7 @@ func (s *Service) handler(ctx context.Context, b *bot.Bot, m *models.Update) {
 
 	b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:              m.Message.Chat.ID,
-		Text:                fmt.Sprintf("Content saved with [%s](%s/m/%s)", memo.Name, s.config.ServerAddr, memo.Uid),
+		Text:                fmt.Sprintf("Content saved with [%s](%s/m/%s)", memo.Name, s.config.MemosAddr, memo.Uid),
 		ParseMode:           models.ParseModeMarkdown,
 		DisableNotification: true,
 		ReplyParameters: &models.ReplyParameters{


### PR DESCRIPTION
This pull request fixes the URL in the bot message by updating the `Text` field in the `handler` function. The URL now correctly points to the `MemosAddr` instead of the `ServerAddr`.